### PR TITLE
Änderungen Christian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VER
 RUN { \
       echo 'server_tokens off;'; \
       echo 'client_max_body_size 100m;'; \
+      echo 'proxy_connect_timeout 600;'; \
+      echo 'proxy_send_timeout 600;'; \
+      echo 'proxy_read_timeout 600;'; \
+      echo 'send_timeout 600;'; \
     } > /etc/nginx/conf.d/my_proxy.conf
 
 COPY . /app/


### PR DESCRIPTION
Hi, ich habe noch die Zeilen       
      echo 'proxy_connect_timeout 600;'; \
      echo 'proxy_send_timeout 600;'; \
      echo 'proxy_read_timeout 600;'; \
      echo 'send_timeout 600;'; \
eingefügt, die sind für Odoo wichtig. Aber die Datei /etc/nginx/conf.d/my_proxy.conf wird gar nicht erstellt, das konnte ich noch nicht lösen. :-(